### PR TITLE
feat: support guesses with TypeSpec

### DIFF
--- a/docs/src/examples.md
+++ b/docs/src/examples.md
@@ -813,6 +813,11 @@ to be set:
 2. You must define a custom loss function that can handle your type and produce a real-valued loss. This can be done with `elementwise_loss`, `loss_function`, or `loss_function_expression`. (You can declare the return type as, e.g., `loss_type=Float64` in your type spec, or this will be inferred automatically).
 3. You must define custom operators that accept and return your type. PySR will perform a check that the operators are type-stable, and will raise an error if they are not. Add an explicit return annotation such as `::Vec2` when Julia cannot infer it.
 
+`guesses` work with a type spec as well. Constants in a guess are written as Julia
+code and evaluated where your type is defined, so
+`guesses=["add_vectors(x0, Vec2([1.0, 2.0]))"]` seeds the search with that vector,
+and the printed form of any equation can be passed straight back in as a guess.
+
 We will look at some examples below.
 
 ### Vector-valued expression trees

--- a/pysr/sr.py
+++ b/pysr/sr.py
@@ -67,6 +67,7 @@ from .type_specs import (
     compile_type_spec_runtime_for_model,
     create_type_spec_addprocs_function,
     create_type_spec_exports,
+    create_type_spec_guess_parser,
     load_type_spec_runtime,
     prepare_type_spec_fit_data,
     prepare_type_spec_prediction_data,
@@ -2680,7 +2681,17 @@ class PySRRegressor(MultiOutputMixin, RegressorMixin, BaseEstimator):
         else:
             jl_y_variable_names = None
 
-        jl_guesses = _prepare_guesses_for_julia(self.guesses, self.nout_)
+        jl_guesses = _prepare_guesses_for_julia(
+            self.guesses,
+            self.nout_,
+            guess_parser=(
+                create_type_spec_guess_parser(
+                    type_spec_runtime, options, self.feature_names_in_
+                )
+                if type_spec_runtime is not None and self.guesses is not None
+                else None
+            ),
+        )
 
         # Convert worker_imports to Julia symbols
         jl_worker_imports = (
@@ -3410,7 +3421,7 @@ def calculate_scores(df: pd.DataFrame) -> pd.DataFrame:
     )
 
 
-def _prepare_guesses_for_julia(guesses, nout) -> VectorValue | None:
+def _prepare_guesses_for_julia(guesses, nout, guess_parser=None) -> VectorValue | None:
     """Convert Python guesses to Julia format.
 
     Parameters
@@ -3419,6 +3430,8 @@ def _prepare_guesses_for_julia(guesses, nout) -> VectorValue | None:
         Initial guesses for equations
     nout : int
         Number of output dimensions
+    guess_parser : callable | None
+        TypeSpec-aware converter, used in place of the numeric conversion
 
     Returns
     -------
@@ -3456,7 +3469,9 @@ def _prepare_guesses_for_julia(guesses, nout) -> VectorValue | None:
     for output_guesses in g:
         julia_output_guesses = []
         for item in output_guesses:
-            if isinstance(item, dict):
+            if guess_parser is not None:
+                julia_output_guesses.append(guess_parser(item))
+            elif isinstance(item, dict):
                 # Convert dict to NamedTuple for template expressions
                 julia_output_guesses.append(jl_named_tuple(item))
             else:

--- a/pysr/test/test_type_specs.py
+++ b/pysr/test/test_type_specs.py
@@ -590,7 +590,6 @@ print(json.dumps({{
     def test_unsupported_configurations_fail_before_runtime_loading(self):
         X, y = string_data()
         cases = (
-            (tiny_model(string_spec(), guesses=["x0"]), ValueError, "guesses"),
             (tiny_model(string_spec(), turbo=True), ValueError, "turbo"),
             (tiny_model(string_spec(), bumper=True), ValueError, "bumper"),
             (
@@ -1155,6 +1154,75 @@ print(json.dumps({{
                     operators={1: ["identity_value(x::StringValue) = x"]},
                     n_features_in=1,
                 )
+
+    def test_guess_seeds_the_search_with_a_custom_constant(self):
+        type_name = "GuessVectorValue"
+        model = tiny_model(
+            vector_spec(name=type_name),
+            operators={
+                2: [
+                    f"add_vectors(a::{type_name}, b::{type_name}) = "
+                    f"{type_name}(a.data + b.data)"
+                ]
+            },
+            elementwise_loss=(
+                f"vector_loss(a::{type_name}, b::{type_name})::Float64 = "
+                "sum(abs2, a.data - b.data)"
+            ),
+            guesses=[f"add_vectors(x0, {type_name}([1.5, -2.5]))"],
+        )
+        X = np.empty((4, 1), dtype=object)
+        X[:, 0] = [np.array([1.0, 2.0])] * 4
+        y = np.empty(4, dtype=object)
+        y[:] = [np.array([2.5, -0.5])] * 4
+
+        model.fit(X, y)
+
+        self.assertEqual(model.equations_.loss.min(), 0.0)
+        self.assertIn("[1.5, -2.5]", " ".join(model.equations_.equation))
+
+    def test_template_guess_seeds_each_expression(self):
+        type_name = "GuessTemplateValue"
+        model = tiny_model(
+            string_spec(name=type_name),
+            expression_spec=TemplateExpressionSpec(
+                combine="f(x)",
+                expressions=["f"],
+                variable_names=["x"],
+            ),
+            operators={
+                2: [
+                    f"concat(a::{type_name}, b::{type_name}) = "
+                    f"{type_name}(a.data * b.data)"
+                ]
+            },
+            elementwise_loss=(
+                f"string_loss(a::{type_name}, b::{type_name})::Float64 = "
+                "a.data == b.data ? 0.0 : 1.0"
+            ),
+            guesses=[{"f": 'concat(#1, "!")'}],
+        )
+        X = np.array([["a"], ["b"], ["a"], ["b"]], dtype=object)
+        y = np.array(["a!", "b!", "a!", "b!"], dtype=object)
+
+        model.fit(X, y, variable_names=["x"])
+
+        self.assertEqual(model.equations_.loss.min(), 0.0)
+        self.assertIn('concat(#1, "!")', " ".join(model.equations_.equation))
+
+    def test_guess_rejects_a_constant_that_is_not_the_custom_type(self):
+        type_name = "GuessConversionValue"
+        model = tiny_model(
+            vector_spec(name=type_name),
+            guesses=[f"identity_{type_name}(2.0)"],
+        )
+        X = np.empty((4, 1), dtype=object)
+        X[:, 0] = [np.array([1.0, 2.0])] * 4
+        y = np.empty(4, dtype=object)
+        y[:] = [np.array([1.0, 2.0])] * 4
+
+        with self.assertRaisesRegex(ValueError, "constructor syntax"):
+            model.fit(X, y)
 
     def test_template_custom_combiner_infers_num_features(self):
         type_name = "TemplateVectorValue"

--- a/pysr/type_specs.py
+++ b/pysr/type_specs.py
@@ -4,6 +4,7 @@ import copy
 import hashlib
 import json
 import warnings
+from collections.abc import Callable, Iterable
 from dataclasses import dataclass
 from functools import cache
 from textwrap import dedent
@@ -13,7 +14,7 @@ import numpy as np
 import pandas as pd
 from juliacall import JuliaError  # type: ignore
 
-from .julia_helpers import jl_array
+from .julia_helpers import jl_array, jl_named_tuple
 from .julia_import import AnyValue, SymbolicRegression, jl
 
 _TYPE_MODULE_INSTALLED = "_PYSR_TYPE_SPEC_INSTALLED"
@@ -1122,6 +1123,126 @@ def validate_type_spec_options(
         raise ValueError(str(jl.sprint(jl.showerror, error.args[0]))) from error
 
 
+@cache
+def _type_spec_guess_parser() -> AnyValue:
+    return jl.seval(r"""
+        begin
+            import Random
+            function (module_, options, T, variable_names, guess)
+                DE = SymbolicRegression.InterfaceDynamicExpressionsModule.DE
+                operators = options.operators
+                is_operator(name) =
+                    name isa Symbol &&
+                    any(ops -> any(op -> nameof(op) === name, ops), operators.ops)
+                uses_variable(ex, names) =
+                    ex isa Symbol ? string(ex) in names :
+                    ex isa Expr ? any(arg -> uses_variable(arg, names), ex.args) : false
+                function constant(value)
+                    value isa T && return value
+                    try
+                        return value isa Tuple ? T(value...) : T(value)
+                    catch
+                        throw(ArgumentError(
+                            "Cannot use `$value` as a `$T` constant. " *
+                            "Write constants with `$T` constructor syntax."
+                        ))
+                    end
+                end
+                # Operator calls stay symbolic; every other sub-expression is a
+                # constant, evaluated where the type and its helpers are defined.
+                function fold(ex, names)
+                    if ex isa Expr && ex.head === :call && is_operator(ex.args[1])
+                        children = map(arg -> fold(arg, names), ex.args[2:end])
+                        return Expr(:call, ex.args[1], children...)
+                    elseif uses_variable(ex, names)
+                        return ex
+                    else
+                        return constant(Core.eval(module_, ex))
+                    end
+                end
+                guess isa NamedTuple || return fold(Meta.parse(guess), variable_names)
+
+                # Template guesses: `#i` is the i-th argument of each expression.
+                eval_context =
+                    if SymbolicRegression.InterfaceDynamicExpressionsModule.takes_eval_context(
+                        operators
+                    )
+                        (; eval_context=SymbolicRegression.EvalContext(;
+                            options.turbo, options.bumper
+                        ))
+                    else
+                        NamedTuple()
+                    end
+                contents = map(guess) do source
+                    count = maximum(
+                        (parse(Int, m[1]) for m in eachmatch(r"#(\d+)", source)); init=0
+                    )
+                    arguments = ["__arg_$i" for i in 1:count]
+                    tree = DE.parse_expression(
+                        fold(
+                            Meta.parse(replace(source, r"#(\d+)" => s"__arg_\1")),
+                            arguments,
+                        );
+                        operators,
+                        variable_names=arguments,
+                        expression_type=DE.Expression,
+                        node_type=DE.with_type_parameters(options.node_type, T),
+                    ).tree
+                    SymbolicRegression.ComposableExpression(
+                        tree; operators, variable_names=nothing, eval_context...
+                    )
+                end
+                structure = options.expression_options.structure
+                parameters = if isempty(structure.num_parameters)
+                    NamedTuple()
+                else
+                    (;
+                        parameters=SymbolicRegression.TemplateExpressionModule._initialize_template_parameters(
+                            Random.default_rng(),
+                            T,
+                            structure.num_parameters,
+                            get(options.expression_options, :parameter_initializer, nothing),
+                            options,
+                        ),
+                    )
+                end
+                return SymbolicRegression.TemplateExpression(
+                    contents;
+                    structure,
+                    operators,
+                    variable_names=nothing,
+                    parameters...,
+                )
+            end
+        end
+        """)
+
+
+def create_type_spec_guess_parser(
+    runtime: _TypeSpecRuntime, options: AnyValue, variable_names: Iterable[Any]
+) -> Callable[[Any], AnyValue]:
+    """Parse guesses, evaluating custom constants where the type is defined."""
+    parser = _type_spec_guess_parser()
+    names = jl_array([str(name) for name in variable_names])
+
+    def parse_guess(guess: Any) -> AnyValue:
+        try:
+            return parser(
+                runtime.configuration_module,
+                options,
+                runtime.value_type,
+                names,
+                jl_named_tuple(guess) if isinstance(guess, dict) else guess,
+            )
+        except JuliaError as error:
+            raise ValueError(
+                f"Failed to parse TypeSpec guess {guess!r}: "
+                + str(jl.sprint(jl.showerror, error.args[0]))
+            ) from error
+
+    return parse_guess
+
+
 def type_spec_to_julia_array(
     runtime: _TypeSpecRuntime, values: Any, *, transpose: bool = False
 ) -> AnyValue:
@@ -1315,7 +1436,6 @@ def validate_type_spec_model_configuration(model: Any) -> None:
         loss_function_expression=model.loss_function_expression,
     )
     unsupported = {
-        "guesses": model.guesses is not None,
         "turbo": model.turbo,
         "bumper": model.bumper,
         "autodiff_backend": model.autodiff_backend is not None,


### PR DESCRIPTION
Follow-up to #1280: `guesses=` now works with `type_spec=`, including custom-typed constants and template guesses.

## How

A guess is parsed against the runtime module of the type spec. Operator calls stay symbolic; every other sub-expression is a constant and is evaluated in the module where the custom type, its `preamble`, and its operators are defined. The resulting `Expr` (with real values spliced in as leaves) is handed to SymbolicRegression, which parses it with the search's own node type and operators.

Consequences:

- constants use ordinary Julia constructor syntax: `guesses=["add_vectors(x0, Vec2([1.0, 2.0]))"]`
- that is also what the default `string` hook prints, so hall-of-fame equations round-trip straight back in as guesses (verified: `rt_add(x0, [1.0, 2.0])` refits to loss 0)
- a leaf that is not the custom type is converted with `T(value)`, which is what makes the printed single-field form (`[1.0, 2.0]`) parse back
- a value that cannot be converted gets a clear error naming the type instead of a `MethodError`

No new `TypeSpec` field, and no changes needed in SymbolicRegression.jl or DynamicExpressions.jl.

Template guesses take the same path: `#i` is rewritten to the i-th argument leaf per expression, each field is folded and parsed, then wrapped into a `TemplateExpression`.

## Tests

Three tests in `test_type_specs.py`: a vector constant that random sampling cannot produce (proving the guess seeded the search), a template guess, and the conversion-failure message. `guesses` is removed from the unsupported-configuration list.

`pytest pysr/test/test_type_specs.py` -> 54 passed; `pytest pysr/test/test_main.py -k guess` -> 16 passed.

## Note

The root-cause fix upstream would be a parse-scope argument in DynamicExpressions (its parser resolves symbols in an empty module), which would let plain strings work with no PySR pre-parsing at all. This PR does not need it.