### PR TITLE
feat(types): add an optional invalid value hook

### DIFF
--- a/pysr/juliapkg.json
+++ b/pysr/juliapkg.json
@@ -1,6 +1,10 @@
 {
     "julia": "=1.10.0, 1.10.3",
     "packages": {
+        "DynamicExpressions": {
+            "uuid": "a40a106e-89c9-4ca8-8020-a735e8728b6b",
+            "version": "^2.10.1"
+        },
         "SymbolicRegression": {
             "uuid": "8254be44-1295-4e6a-a16d-46603ac705cb",
             "version": "~2.4.0",

--- a/pysr/test/test_type_specs.py
+++ b/pysr/test/test_type_specs.py
@@ -103,6 +103,39 @@ def string_data(*, constant: bool = False):
 
 
 class TestTypeSpecs(unittest.TestCase):
+    def test_invalid_value_hook(self):
+        spec = string_spec(
+            invalid='() -> StringValue("")',
+            is_valid="value -> !isempty(value.data)",
+        )
+        runtime = load_type_spec_runtime(compile_type_spec(spec))
+
+        self.assertTrue(
+            jl.seval(
+                "T -> begin v = SymbolicRegression.InterfaceDynamicExpressionsModule.DE.invalid_value(T); v isa T && isempty(v.data) end"
+            )(runtime.value_type)
+        )
+        X, y = string_data()
+        model = tiny_model(spec)
+        model.fit(X, y)
+        self.assertEqual(model.predict(X).tolist(), y.tolist())
+
+    def test_invalid_hook_rejects_wrong_type_or_valid_value(self):
+        for source, message in (
+            ('() -> ""', "invalid.*must return `StringValue`"),
+            ('() -> StringValue("valid")', "invalid.*must return an invalid value"),
+        ):
+            with self.subTest(source=source):
+                runtime = load_type_spec_runtime(
+                    compile_type_spec(
+                        string_spec(
+                            invalid=source, is_valid="value -> !isempty(value.data)"
+                        )
+                    )
+                )
+                with self.assertRaisesRegex(ValueError, message):
+                    validate_type_spec_runtime(runtime)
+
     def test_serial_string_type_spec(self):
         X, y = string_data()
         model = tiny_model(string_spec())

--- a/pysr/type_specs.py
+++ b/pysr/type_specs.py
@@ -89,6 +89,12 @@ class TypeSpec:
         you may use this function to check for that. This will be used to quit evaluation early.
         The default checks that every scalar constant is finite, or accepts every value for a
         non-optimizable type.
+    invalid : str, optional
+        Julia callable with signature ``() -> value::{name}`` that constructs an
+        invalid value. The result must have this type and fail ``is_valid``.
+        Used by DynamicExpressions to fill failed convenience evaluations.
+        Omit this hook for types with no invalid state. It receives no prototype
+        or shape information.
     string : str, optional
         Julia callable with signature ``value::{name} -> (...)::AbstractString`` used to print
         values.
@@ -113,6 +119,7 @@ class TypeSpec:
     string: str | None = None
     preamble: str | None = None
     loss_type: str | None = None
+    invalid: str | None = None
 
     def __post_init__(self) -> None:
         if not isinstance(self.name, str) or not self.name.isidentifier():
@@ -143,6 +150,7 @@ class TypeSpec:
             "init",
             "mutate",
             "is_valid",
+            "invalid",
             "string",
             "preamble",
             "loss_type",
@@ -452,7 +460,7 @@ _TYPE_SPEC_MODULE = _block(r"""
     import SymbolicRegression.ConstantOptimizationModule: can_optimize
     import SymbolicRegression.InterfaceDynamicExpressionsModule: string_constant
     import SymbolicRegression.InterfaceDynamicExpressionsModule.DE:
-        count_scalar_constants, get_number_type, is_valid,
+        count_scalar_constants, get_number_type, is_valid, invalid_value,
         pack_scalar_constants!, unpack_scalar_constants
     import SymbolicRegression.InterfaceDynamicExpressionsModule.DE.StringsModule:
         needs_brackets
@@ -562,6 +570,11 @@ _TYPE_SPEC_MODULE = _block(r"""
         _ -> true
     end
     is_valid(value::_TypeSpecValue) = _is_valid(value)
+
+    if _config.invalid !== nothing
+        const _invalid = _include(_config.invalid, "TypeSpec.invalid")
+        invalid_value(::Type{<:_TypeSpecValue}) = _invalid()
+    end
 
     const _string = if _config.string === nothing
         function (value)
@@ -681,6 +694,7 @@ def compile_type_spec(spec: TypeSpec) -> _TypeSpecDefinition:
             init = {_optional_source(spec.init)},
             mutate = {_optional_source(spec.mutate)},
             is_valid = {_optional_source(spec.is_valid)},
+            invalid = {_optional_source(spec.invalid)},
             string = {_optional_source(spec.string)},
             preamble = {_optional_source(spec.preamble)},
             optimizable = {str(spec.can_optimize).lower()},
@@ -1001,6 +1015,14 @@ def _type_spec_validator() -> AnyValue:
             for value in (initial, sampled)
                 count = scalar_constant_count(value)
                 optimizable && check_optimization(value, count)
+            end
+
+            if module_._config.invalid !== nothing
+                invalid = call("invalid", DE.invalid_value, T)
+                invalid isa T || fail("invalid", "must return `$type_name`.")
+                valid = call("is_valid", DE.is_valid, invalid)
+                valid isa Bool || fail("is_valid", "must return `Bool`.")
+                !valid || fail("invalid", "must return an invalid value.")
             end
 
             mutated = check_value(


### PR DESCRIPTION
## Why
Custom TypeSpec values need a way to construct an invalid result without adding a scalar constructor to the Julia type.

## Scope
- Add optional `TypeSpec(invalid="() -> value")`, following the existing `init` callable convention.
- Generate `DynamicExpressions.invalid_value(T)` and validate that its result has type `T` and fails `is_valid`.
- Declare DynamicExpressions directly in `pysr/juliapkg.json` with its registry UUID. The docs Julia project does not load this backend and needs no extra dependency.

## Tradeoffs
**Dependent draft. Do not merge or release this PR yet.**

This requires https://github.com/SymbolicML/DynamicExpressions.jl/pull/209 and a registered DynamicExpressions release containing that change. The latest real release is 2.10.1, which lacks `invalid_value`. The current `^2.10.1` constraint records the tested compatible series, but it does not enforce the new API. Before merge, replace that lower bound with the first actual registered release containing #209, then rerun ordinary resolver and CI tests. No future release number is invented here.

The Force example and its documentation mirror live in dependent docs PR https://github.com/astroautomata/PySR/pull/1350, not current master. Their scoped migration is to remove `Force(u::Real) = Force(u,u,u)` from `sample`, use `sample="rng -> Force(randn(rng, 3)...)"`, and add `invalid="() -> Force(NaN, NaN, NaN)"`. The matching prose must describe the invalid hook. Both revised definitions were compiled and compared locally; the complete example passed a small fit/predict smoke run. The existing dirty docs branch and definitions PR #1359 are untouched.

## Blast Radius
Types without invalid states can omit this hook. Existing positional TypeSpec parameters retain their positions. Runtime hook loading does not invoke the constructor; validation does.

## Verification
- Local `Pkg.develop` integration resolved this backend checkout, SymbolicRegression 2.4.0, and PythonCall 0.9.35. No local source overrides are committed.
- New invalid-hook and wrong-type/valid-result rejection tests passed through the actual Julia/Python runtime. The existing serial string fit/predict test also passed.
- Revised Force example fit 24 rows with 5 iterations and produced 8 finite three-component predictions without a scalar constructor. This smoke run does not claim scientific recovery accuracy.
- The revised script and docs Force definitions matched and compiled the invalid constructor.
- All scoped pre-commit hooks passed.
- An independent fresh resolver check confirmed released DynamicExpressions 2.10.1 lacks the hook, so release-backed tests remain blocked as described above.
